### PR TITLE
feat(Recovery): tiered self-healing — app restart, reboot, container recreation [P157]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,8 @@ SCANNER_CONTAINER_NAME="CONTAINER_NAME"
 #ADB
 ADB_DEVICE="192.168.1.222:5555"   # TCP/IP address of the Android device
 #!ADB
+
+#STACK_RECOVERY
+UNOWNHASH_COMPOSE_FILE="/root/unonwhash/docker-compose.yml"  # scanner stack compose file (mounted read-only in prod)
+RECREATE_SERVICES="dragonite rotom-ng"                        # services recreated when the map goes fully red
+#!STACK_RECOVERY

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Standalone docker compose v2 binary — used by StackRecovery to force-recreate
+# the scanner containers over the host's docker.sock (mounted in prod compose)
+ADD https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-x86_64 /usr/local/bin/docker-compose
+RUN chmod +x /usr/local/bin/docker-compose
+
 WORKDIR /app
 
 # Cached pip layer: only invalidated when requirements.txt changes

--- a/cogs/container_manager.py
+++ b/cogs/container_manager.py
@@ -86,7 +86,8 @@ class ContainerManagerCog(commands.Cog):
     @commands.group(name="container", invoke_without_command=True)
     async def container(self, ctx):
         await ctx.send(
-            "Invalid container command. Use `container start` or `container stop`."
+            "Invalid container command. Use `container start`, `container stop`, "
+            "`container recreate` or `container autorecreate on|off`."
         )
 
     @container.command(name="start")
@@ -127,6 +128,48 @@ class ContainerManagerCog(commands.Cog):
             self.poliswag.utility.log_to_file(error_message, "ERROR")
             await ctx.send(error_message)
 
+    @container.command(name="recreate")
+    async def recreate_containers(self, ctx):
+        msg = await ctx.send(f"⏳ A recriar containers `{Config.RECREATE_SERVICES}`…")
+        ok = await self.poliswag.stack_recovery.recreate_services()
+        if ok:
+            await msg.edit(
+                content=f"✅ Containers `{Config.RECREATE_SERVICES}` recriados."
+            )
+            self.poliswag.utility.log_to_file(
+                f"[CONTAINER] @{ctx.author} ({ctx.author.id}): recreated "
+                f"'{Config.RECREATE_SERVICES}'"
+            )
+        else:
+            await msg.edit(content="❌ Falha ao recriar containers. Verifica os logs.")
+            self.poliswag.utility.log_to_file(
+                f"[CONTAINER] @{ctx.author} ({ctx.author.id}): recreate FAILED",
+                "ERROR",
+            )
+
+    @container.command(name="autorecreate")
+    async def container_autorecreate(self, ctx, state: str = None):
+        if state is None:
+            current = self.poliswag.stack_recovery.auto_recreate_enabled
+            status = "activada 🟢" if current else "desactivada 🔴"
+            await ctx.send(f"Recriação automática: **{status}**. Usa `on` ou `off`.")
+            return
+        state = state.lower()
+        if state in ("on", "enable", "1", "true"):
+            self.poliswag.stack_recovery.auto_recreate_enabled = True
+            await ctx.send("✅ Recriação automática de containers **activada**.")
+            self.poliswag.utility.log_to_file(
+                f"[CONTAINER] @{ctx.author} ({ctx.author.id}): auto-recreate ENABLED"
+            )
+        elif state in ("off", "disable", "0", "false"):
+            self.poliswag.stack_recovery.auto_recreate_enabled = False
+            await ctx.send("🔕 Recriação automática de containers **desactivada**.")
+            self.poliswag.utility.log_to_file(
+                f"[CONTAINER] @{ctx.author} ({ctx.author.id}): auto-recreate DISABLED"
+            )
+        else:
+            await ctx.send("Estado inválido. Usa `on` ou `off`.")
+
     # ---- !device command group --------------------------------------------
 
     @commands.group(name="device", invoke_without_command=True)
@@ -135,8 +178,27 @@ class ContainerManagerCog(commands.Cog):
             "`!device status` — verifica ligação ADB\n"
             "`!device logcat [linhas]` — últimas N linhas filtradas por aegis/poke (padrão 10)\n"
             "`!device autoreboot on|off` — activa/desactiva reboot automático\n"
+            "`!device restartapp` — reinicia a app Pokémon GO via ADB\n"
             "`!device reboot` — reinicia o dispositivo via ADB"
         )
+
+    @device.command(name="restartapp", brief="Reinicia a app Pokémon GO via ADB")
+    async def device_restartapp(self, ctx):
+        msg = await ctx.send("⏳ A reiniciar a app…")
+        ok = await self.poliswag.device_manager.restart_app()
+        if ok:
+            await msg.edit(content="✅ App Pokémon GO reiniciada via ADB.")
+            self.poliswag.utility.log_to_file(
+                f"[DEVICE] @{ctx.author} ({ctx.author.id}): manual app restart sent"
+            )
+        else:
+            await msg.edit(
+                content="❌ Falha ao reiniciar a app. Verifica `!device status`."
+            )
+            self.poliswag.utility.log_to_file(
+                f"[DEVICE] @{ctx.author} ({ctx.author.id}): manual app restart FAILED",
+                "ERROR",
+            )
 
     @device.command(name="status", brief="Verifica ligação ADB ao dispositivo")
     async def device_status(self, ctx):

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -13,6 +13,11 @@ services:
       - /root/PoGoLeiria/apps/quests/public:/pogo-public
       - /root/PoGoLeiria/apps/dex/public:/dex-public
       - /root/.android:/root/.android:ro
+      # StackRecovery: recreate scanner containers when the map goes fully red.
+      # The stack dir is mounted at its host path so compose resolves the
+      # project name and relative bind mounts identically to a host-side run.
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /root/unonwhash:/root/unonwhash:ro
     env_file:
       - .env
     networks:

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from modules.account_monitor import AccountMonitor
 from modules.poracle_client import PoracleClient
 from modules.device_manager import DeviceManager
 from modules.lure_manager import LureManager
+from modules.stack_recovery import StackRecovery
 from modules.config import Config
 from modules.http_client import close_session
 
@@ -43,6 +44,7 @@ class Poliswag(commands.Bot):
         self.poracle = PoracleClient(self)
         self.device_manager = DeviceManager(self)
         self.lure_manager = LureManager(self)
+        self.stack_recovery = StackRecovery(self)
 
         self.QUEST_CHANNEL = None
         self.CONVIVIO_CHANNEL = None

--- a/migrations/005_add_auto_recreate_enabled.sql
+++ b/migrations/005_add_auto_recreate_enabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE poliswag
+  ADD COLUMN IF NOT EXISTS auto_recreate_enabled tinyint(1) NOT NULL DEFAULT 1;

--- a/mock_data/device_status.json
+++ b/mock_data/device_status.json
@@ -1,8 +1,8 @@
 {
   "devices": [
     {
-      "dateLastMessageReceived": 1784279497748,
-      "dateLastMessageSent": 1784279497748,
+      "dateLastMessageReceived": 1784284997896,
+      "dateLastMessageSent": 1784284997896,
       "deviceId": "PoGoLeiria",
       "init": false,
       "instanceNo": 4,

--- a/mock_data/scanner_status.json
+++ b/mock_data/scanner_status.json
@@ -8,17 +8,17 @@
           "workers": [
             {
               "worker_id": "leiria-worker-1",
-              "last_data": 1784279497,
+              "last_data": 1784284997,
               "connection_status": "Executing Worker"
             },
             {
               "worker_id": "leiria-worker-2",
-              "last_data": 1784279497,
+              "last_data": 1784284997,
               "connection_status": "Executing Worker"
             },
             {
               "worker_id": "leiria-worker-3",
-              "last_data": 1784279497,
+              "last_data": 1784284997,
               "connection_status": "Executing Worker"
             }
           ]
@@ -33,7 +33,7 @@
           "workers": [
             {
               "worker_id": "marinha-worker-1",
-              "last_data": 1784279497,
+              "last_data": 1784284997,
               "connection_status": "Executing Worker"
             }
           ]

--- a/mock_database/init.sql
+++ b/mock_database/init.sql
@@ -844,6 +844,7 @@ CREATE TABLE `poliswag` (
   `last_scanned_date` datetime DEFAULT NULL,
   `last_weekly_digest_date` date DEFAULT NULL,
   `auto_reboot_enabled` tinyint(1) NOT NULL DEFAULT 1,
+  `auto_recreate_enabled` tinyint(1) NOT NULL DEFAULT 1,
   `quest_expected_leiria` int(11) NOT NULL DEFAULT 371,
   `quest_expected_marinha` int(11) NOT NULL DEFAULT 109
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/modules/config.py
+++ b/modules/config.py
@@ -31,6 +31,10 @@ class Config:
     # Scanner / infrastructure
     SCANNER_CONTAINER_NAME = os.environ.get("SCANNER_CONTAINER_NAME")
     ADB_DEVICE = os.environ.get("ADB_DEVICE", "")  # e.g. "192.168.1.222:5555"
+    UNOWNHASH_COMPOSE_FILE = os.environ.get(
+        "UNOWNHASH_COMPOSE_FILE", "/root/unonwhash/docker-compose.yml"
+    )
+    RECREATE_SERVICES = os.environ.get("RECREATE_SERVICES", "dragonite rotom-ng")
     ENV = os.environ.get("ENV", "DEV")
     IS_PRODUCTION = ENV == "PRODUCTION"
 

--- a/modules/device_manager.py
+++ b/modules/device_manager.py
@@ -7,16 +7,25 @@ from modules.config import Config
 class DeviceManager:
     """Manages ADB interactions with the configured Android device."""
 
-    # How long the device must be continuously offline before an auto-reboot fires.
+    # How long the device must be continuously offline before recovery starts.
     OFFLINE_BEFORE_REBOOT = 900  # 15 minutes offline before acting
     # Minimum gap between reboots — long enough for the device to fully boot + reconnect.
     AUTO_REBOOT_COOLDOWN = 1800  # 30 minutes between reboots
+    # Tier 1: restart the app first; only reboot if it's still down this much later.
+    APP_RESTART_GRACE = 600  # 10 minutes for the app restart to take effect
+
+    POGO_PACKAGE = "com.nianticlabs.pokemongo"
+    POGO_ACTIVITY = (
+        "com.nianticlabs.pokemongo/"
+        "com.nianticproject.holoholo.libholoholo.unity.UnityMainActivity"
+    )
 
     def __init__(self, poliswag):
         self.poliswag = poliswag
         self._last_auto_reboot: float = 0
         self._offline_since: float | None = None
         self._last_notification_time: float = 0
+        self._app_restart_time: float | None = None
 
     @property
     def auto_reboot_enabled(self) -> bool:
@@ -154,6 +163,25 @@ class DeviceManager:
         except RuntimeError:
             return False
 
+    async def restart_app(self) -> bool:
+        """Force-stop and relaunch Pokémon GO. Much lighter than a reboot.
+
+        Aegis re-injects when the game starts, so a plain activity launch is
+        enough to bring the MITM worker back after an app-level wedge.
+        """
+        try:
+            _, _, rc = await self.run(
+                "shell", "am", "force-stop", self.POGO_PACKAGE, timeout=15
+            )
+            if rc != 0:
+                return False
+            _, _, rc = await self.run(
+                "shell", "am", "start", "-n", self.POGO_ACTIVITY, timeout=15
+            )
+            return rc == 0
+        except RuntimeError:
+            return False
+
     def _next_notify_interval(self, offline_duration: float) -> float:
         """Escalating gap between repeated offline notifications."""
         if offline_duration < 6 * 3600:
@@ -161,12 +189,16 @@ class DeviceManager:
         return 6 * 3600  # every 6 h after that
 
     async def auto_reboot_if_offline(self) -> bool:
-        """Reboot the device if Rotom reports it offline long enough.
+        """Recover the device if Rotom reports it offline long enough.
+
+        Tiered: at OFFLINE_BEFORE_REBOOT (15 min) the app is restarted first —
+        an app-level wedge is the common case and costs ~30s instead of a full
+        boot. If the device is still offline APP_RESTART_GRACE (10 min) after
+        that, the device is rebooted, respecting AUTO_REBOOT_COOLDOWN (30 min).
 
         Notification cadence:
         - First alert at OFFLINE_BEFORE_REBOOT (15 min).
         - Repeated every 1 h while offline < 6 h, then every 6 h.
-        Reboot attempts respect AUTO_REBOOT_COOLDOWN (30 min) independently.
         """
         if not Config.ADB_DEVICE or not self.auto_reboot_enabled:
             return False
@@ -177,6 +209,7 @@ class DeviceManager:
         if device_alive:
             self._offline_since = None
             self._last_notification_time = 0
+            self._app_restart_time = None
             return False
 
         if self._offline_since is None:
@@ -188,7 +221,32 @@ class DeviceManager:
         if offline_duration < self.OFFLINE_BEFORE_REBOOT:
             return False
 
-        # Attempt reboot if cooldown allows
+        # Tier 1: one app restart per offline episode, before any reboot.
+        if self._app_restart_time is None:
+            self._log(
+                f"Device offline for {int(offline_duration)}s — restarting the app first",
+                "INFO",
+            )
+            restarted = await self.restart_app()
+            if restarted:
+                self._app_restart_time = now
+                await self._notify(
+                    f"📵 Dispositivo offline há **{int(offline_duration // 60)} min** — "
+                    f"app reiniciada via ADB (tier 1). Reboot completo em "
+                    f"{self.APP_RESTART_GRACE // 60} min se continuar em baixo."
+                )
+                return True
+            # Failed restart gets no grace period — escalate to reboot now.
+            self._app_restart_time = now - self.APP_RESTART_GRACE
+            self._log("Tier 1 app restart failed — falling through to reboot")
+
+        # Tier 2: full reboot once the app restart had its grace period.
+        if (
+            self._app_restart_time is not None
+            and now - self._app_restart_time < self.APP_RESTART_GRACE
+        ):
+            return False
+
         since_last_reboot = now - self._last_auto_reboot
         if since_last_reboot >= self.AUTO_REBOOT_COOLDOWN:
             self._log(
@@ -200,6 +258,7 @@ class DeviceManager:
             if rebooted:
                 self._offline_since = None
                 self._last_notification_time = 0
+                self._app_restart_time = None
                 self._log("Auto ADB reboot sent successfully", "INFO")
                 await self._notify(
                     f"📵 Dispositivo offline há **{int(offline_duration // 60)} min** — "

--- a/modules/scanner_status.py
+++ b/modules/scanner_status.py
@@ -81,11 +81,17 @@ class ScannerStatus:
         # pay for the device lookup, so ❌ (device offline) can be told apart
         # from 🔴 (device up, accounts/workers down).
         device_connected = True
-        if "🔴" in (
+        indicators = (
             self._get_status_indicator(leiriaDownCounter, "LEIRIA"),
             self._get_status_indicator(marinhaDownCounter, "MARINHA"),
-        ):
+        )
+        if "🔴" in indicators:
             device_connected = await self.poliswag.account_monitor.is_device_connected()
+
+        # Fully red with the device still connected = stuck account/session
+        # state; StackRecovery recreates the scanner containers if it persists.
+        all_red = indicators == ("🔴", "🔴") and device_connected
+        await self.poliswag.stack_recovery.observe(all_red)
 
         for channel_key, counter, region in [
             ("leiria", leiriaDownCounter, "LEIRIA"),

--- a/modules/stack_recovery.py
+++ b/modules/stack_recovery.py
@@ -1,0 +1,147 @@
+import asyncio
+import time
+
+from modules.config import Config
+
+
+class StackRecovery:
+    """Recreates the scanner-side containers when the map goes fully red.
+
+    "Red" here means every region reports all workers down while the MITM
+    device is still connected — the signature of an exhausted/stuck account
+    pool rather than a device problem. Experience shows a fresh dragonite
+    (and rotom-ng) container clears it, so after the red state persists past
+    RED_BEFORE_RECREATE the affected services are force-recreated via docker
+    compose. The db/golbat/map containers are deliberately left alone.
+    """
+
+    # How long the full-red state must persist before acting.
+    RED_BEFORE_RECREATE = 600  # 10 minutes
+    # Minimum gap between recreations — enough for a full account warm-up.
+    RECREATE_COOLDOWN = 2700  # 45 minutes
+    # docker compose can take a while pulling/recreating; don't hang the loop.
+    RECREATE_TIMEOUT = 180
+
+    def __init__(self, poliswag):
+        self.poliswag = poliswag
+        self._red_since: float | None = None
+        self._last_recreate: float = 0
+
+    def _log(self, msg, level="ERROR"):
+        self.poliswag.utility.log_to_file(msg, level)
+
+    @property
+    def auto_recreate_enabled(self) -> bool:
+        try:
+            rows = self.poliswag.db.get_data_from_database(
+                "SELECT auto_recreate_enabled FROM poliswag LIMIT 1"
+            )
+            return bool(rows[0]["auto_recreate_enabled"]) if rows else True
+        except Exception:
+            return True
+
+    @auto_recreate_enabled.setter
+    def auto_recreate_enabled(self, value: bool) -> None:
+        try:
+            self.poliswag.db.execute_query_to_database(
+                "UPDATE poliswag SET auto_recreate_enabled = %s",
+                params=(1 if value else 0,),
+            )
+        except Exception as e:
+            self._log(f"Failed to persist auto_recreate_enabled: {e}")
+
+    async def observe(self, all_red: bool) -> bool:
+        """Track the red state across ticks; recreate once it persists.
+
+        Called every scheduler tick from the voice-channel status pass.
+        Returns True when a recreation was triggered this tick.
+        """
+        now = time.time()
+
+        if not all_red:
+            self._red_since = None
+            return False
+
+        if self._red_since is None:
+            self._red_since = now
+            return False
+
+        red_duration = now - self._red_since
+        if red_duration < self.RED_BEFORE_RECREATE:
+            return False
+
+        if not self.auto_recreate_enabled:
+            return False
+
+        if now - self._last_recreate < self.RECREATE_COOLDOWN:
+            return False
+
+        self._last_recreate = now
+        self._log(
+            f"Map fully red for {int(red_duration)}s with device connected — "
+            f"recreating {Config.RECREATE_SERVICES}",
+            "INFO",
+        )
+        ok = await self.recreate_services()
+        minutes = int(red_duration // 60)
+        if ok:
+            await self._notify(
+                f"🔄 Mapa em baixo há **{minutes} min** com o dispositivo ligado — "
+                f"containers `{Config.RECREATE_SERVICES}` recriados automaticamente."
+            )
+            # Fresh containers need time to come up; restart the red clock.
+            self._red_since = None
+        else:
+            await self._notify(
+                f"⚠️ Mapa em baixo há **{minutes} min** — recriação automática dos "
+                f"containers **falhou**. Intervenção manual necessária."
+            )
+        return ok
+
+    async def recreate_services(self) -> bool:
+        """Run docker compose up -d --force-recreate on the scanner services."""
+        services = Config.RECREATE_SERVICES.split()
+        cmd = [
+            "docker-compose",
+            "-f",
+            Config.UNOWNHASH_COMPOSE_FILE,
+            "up",
+            "-d",
+            "--force-recreate",
+        ] + services
+
+        if not Config.IS_PRODUCTION:
+            self._log(f"[DEV] Would run: {' '.join(cmd)}", "INFO")
+            return True
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=self.RECREATE_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                self._log(f"Recreate timed out after {self.RECREATE_TIMEOUT}s")
+                return False
+            output = stdout.decode().strip()
+            if proc.returncode != 0:
+                self._log(f"Recreate failed (rc={proc.returncode}): {output[-500:]}")
+                return False
+            self._log(f"Recreated services: {Config.RECREATE_SERVICES}", "INFO")
+            return True
+        except Exception as e:
+            self._log(f"Error recreating services: {e}")
+            return False
+
+    async def _notify(self, message: str) -> None:
+        try:
+            channel = self.poliswag.MOD_CHANNEL
+            if channel:
+                await channel.send(message)
+        except Exception as e:
+            self._log(f"Failed to send stack recovery notification: {e}")

--- a/tests/modules/test_device_manager.py
+++ b/tests/modules/test_device_manager.py
@@ -81,3 +81,115 @@ class TestDeviceState:
     async def test_empty_on_timeout(self, device_manager):
         device_manager._adb = AsyncMock(side_effect=RuntimeError("timeout"))
         assert await device_manager._device_state("d") == ""
+
+
+class TestRestartApp:
+    async def test_force_stop_then_start(self, device_manager, mocker):
+        device_manager.run = AsyncMock(return_value=("", "", 0))
+        assert await device_manager.restart_app() is True
+        calls = device_manager.run.await_args_list
+        assert calls[0].args == (
+            "shell",
+            "am",
+            "force-stop",
+            DeviceManager.POGO_PACKAGE,
+        )
+        assert calls[1].args == (
+            "shell",
+            "am",
+            "start",
+            "-n",
+            DeviceManager.POGO_ACTIVITY,
+        )
+
+    async def test_failed_force_stop_short_circuits(self, device_manager):
+        device_manager.run = AsyncMock(return_value=("", "err", 1))
+        assert await device_manager.restart_app() is False
+        assert device_manager.run.await_count == 1
+
+    async def test_runtime_error_returns_false(self, device_manager):
+        device_manager.run = AsyncMock(side_effect=RuntimeError("timeout"))
+        assert await device_manager.restart_app() is False
+
+
+class TestTieredAutoReboot:
+    """auto_reboot_if_offline: app restart first, reboot only after the grace."""
+
+    def _prime(self, device_manager, mocker, *, now, offline_since):
+        mocker.patch.object(Config, "ADB_DEVICE", "1.2.3.4:5555")
+        mocker.patch.object(
+            type(device_manager),
+            "auto_reboot_enabled",
+            new_callable=mocker.PropertyMock,
+            return_value=True,
+        )
+        device_manager.poliswag.account_monitor.is_device_connected = AsyncMock(
+            return_value=False
+        )
+        device_manager.poliswag.MOD_CHANNEL = None
+        device_manager._offline_since = offline_since
+        mocker.patch("modules.device_manager.time.time", return_value=now)
+
+    async def test_tier1_restarts_app_not_device(self, device_manager, mocker):
+        # 16 min offline, no app restart attempted yet → tier 1 fires.
+        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 960)
+        device_manager.restart_app = AsyncMock(return_value=True)
+        device_manager.reboot = AsyncMock()
+
+        assert await device_manager.auto_reboot_if_offline() is True
+
+        device_manager.restart_app.assert_awaited_once()
+        device_manager.reboot.assert_not_called()
+        assert device_manager._app_restart_time == 10_000
+
+    async def test_tier2_waits_out_the_grace(self, device_manager, mocker):
+        # App restarted 5 min ago (grace is 10) → nothing happens yet.
+        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 1500)
+        device_manager._app_restart_time = 10_000 - 300
+        device_manager.restart_app = AsyncMock()
+        device_manager.reboot = AsyncMock()
+
+        assert await device_manager.auto_reboot_if_offline() is False
+
+        device_manager.restart_app.assert_not_called()
+        device_manager.reboot.assert_not_called()
+
+    async def test_tier2_reboots_after_grace(self, device_manager, mocker):
+        # App restarted 11 min ago and still offline → full reboot.
+        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 2000)
+        device_manager._app_restart_time = 10_000 - 660
+        device_manager.restart_app = AsyncMock()
+        device_manager.reboot = AsyncMock(return_value=True)
+
+        assert await device_manager.auto_reboot_if_offline() is True
+
+        device_manager.restart_app.assert_not_called()
+        device_manager.reboot.assert_awaited_once()
+        # successful reboot resets the episode tracking
+        assert device_manager._offline_since is None
+        assert device_manager._app_restart_time is None
+
+    async def test_failed_app_restart_escalates_immediately(
+        self, device_manager, mocker
+    ):
+        # Tier 1 fails → no grace period, reboot fires in the same tick.
+        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 960)
+        device_manager.restart_app = AsyncMock(return_value=False)
+        device_manager.reboot = AsyncMock(return_value=True)
+
+        assert await device_manager.auto_reboot_if_offline() is True
+
+        device_manager.restart_app.assert_awaited_once()
+        device_manager.reboot.assert_awaited_once()
+
+    async def test_device_back_online_resets_tiers(self, device_manager, mocker):
+        self._prime(device_manager, mocker, now=10_000, offline_since=9_000)
+        device_manager.poliswag.account_monitor.is_device_connected = AsyncMock(
+            return_value=True
+        )
+        device_manager._app_restart_time = 9_500
+
+        assert await device_manager.auto_reboot_if_offline() is False
+
+        assert device_manager._offline_since is None
+        assert device_manager._app_restart_time is None

--- a/tests/modules/test_scanner_status.py
+++ b/tests/modules/test_scanner_status.py
@@ -12,9 +12,12 @@ def scanner_status():
 
     The _log helper routes through poliswag.utility.log_to_file, which the
     MagicMock swallows silently — letting us exercise error paths without
-    touching the real logger.
+    touching the real logger. stack_recovery.observe is awaited from
+    rename_voice_channels, so it needs to be a real AsyncMock.
     """
-    return ScannerStatus(poliswag=MagicMock())
+    poliswag = MagicMock()
+    poliswag.stack_recovery.observe = AsyncMock()
+    return ScannerStatus(poliswag=poliswag)
 
 
 class TestGetStatusMessage:
@@ -771,6 +774,27 @@ class TestRenameVoiceChannels:
         is_connected = scanner_status.poliswag.account_monitor.is_device_connected
         await scanner_status.rename_voice_channels(0, 0)
         is_connected.assert_not_called()
+
+    async def test_all_red_with_device_up_reported_to_stack_recovery(
+        self, scanner_status, mocker
+    ):
+        self._patch_fresh(scanner_status, mocker, seconds_ago=1, device_connected=True)
+        await scanner_status.rename_voice_channels(4, 1)
+        scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(True)
+
+    async def test_device_down_is_not_a_stack_recovery_case(
+        self, scanner_status, mocker
+    ):
+        # Fully red but device offline → ❌ path, not container recreation.
+        self._patch_fresh(scanner_status, mocker, seconds_ago=1, device_connected=False)
+        await scanner_status.rename_voice_channels(4, 1)
+        scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(False)
+
+    async def test_partial_red_is_not_all_red(self, scanner_status, mocker):
+        # Leiria red but Marinha green → no stack recovery trigger.
+        self._patch_fresh(scanner_status, mocker, seconds_ago=1, device_connected=True)
+        await scanner_status.rename_voice_channels(4, 0)
+        scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(False)
 
     async def test_rate_limit_is_logged_not_raised(self, scanner_status, mocker):
         import discord

--- a/tests/modules/test_stack_recovery.py
+++ b/tests/modules/test_stack_recovery.py
@@ -1,0 +1,140 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from modules.stack_recovery import StackRecovery
+
+
+@pytest.fixture
+def stack_recovery(mocker):
+    """A StackRecovery with a mocked poliswag and auto-recreate enabled."""
+    sr = StackRecovery(poliswag=MagicMock())
+    sr.poliswag.MOD_CHANNEL = None
+    mocker.patch.object(
+        type(sr),
+        "auto_recreate_enabled",
+        new_callable=mocker.PropertyMock,
+        return_value=True,
+    )
+    return sr
+
+
+def _at(mocker, now):
+    mocker.patch("modules.stack_recovery.time.time", return_value=now)
+
+
+class TestObserve:
+    async def test_not_red_resets_tracking(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 9_000
+        assert await stack_recovery.observe(False) is False
+        assert stack_recovery._red_since is None
+
+    async def test_first_red_tick_only_arms_the_timer(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery.recreate_services = AsyncMock()
+        assert await stack_recovery.observe(True) is False
+        stack_recovery.recreate_services.assert_not_called()
+        assert stack_recovery._red_since == 10_000
+
+    async def test_red_below_threshold_does_nothing(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 300  # 5 min < 10 min threshold
+        stack_recovery.recreate_services = AsyncMock()
+        assert await stack_recovery.observe(True) is False
+        stack_recovery.recreate_services.assert_not_called()
+
+    async def test_persistent_red_triggers_recreate(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 700  # 11+ min red
+        stack_recovery.recreate_services = AsyncMock(return_value=True)
+        assert await stack_recovery.observe(True) is True
+        stack_recovery.recreate_services.assert_awaited_once()
+        # red clock restarts so the fresh containers get time to come up
+        assert stack_recovery._red_since is None
+
+    async def test_cooldown_blocks_back_to_back_recreates(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 700
+        stack_recovery._last_recreate = 10_000 - 600  # 10 min ago < 45 min cooldown
+        stack_recovery.recreate_services = AsyncMock()
+        assert await stack_recovery.observe(True) is False
+        stack_recovery.recreate_services.assert_not_called()
+
+    async def test_disabled_toggle_blocks_recreate(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        mocker.patch.object(
+            type(stack_recovery),
+            "auto_recreate_enabled",
+            new_callable=mocker.PropertyMock,
+            return_value=False,
+        )
+        stack_recovery._red_since = 10_000 - 700
+        stack_recovery.recreate_services = AsyncMock()
+        assert await stack_recovery.observe(True) is False
+        stack_recovery.recreate_services.assert_not_called()
+
+    async def test_failed_recreate_keeps_red_clock_running(
+        self, stack_recovery, mocker
+    ):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 700
+        stack_recovery.recreate_services = AsyncMock(return_value=False)
+        assert await stack_recovery.observe(True) is False
+        # failure: red_since stays armed so the alert cadence continues
+        assert stack_recovery._red_since == 10_000 - 700
+
+
+class TestRecreateServices:
+    async def test_dev_mode_is_dry_run(self, stack_recovery, mocker):
+        mocker.patch("modules.stack_recovery.Config.IS_PRODUCTION", False)
+        create = mocker.patch("modules.stack_recovery.asyncio.create_subprocess_exec")
+        assert await stack_recovery.recreate_services() is True
+        create.assert_not_called()
+
+    async def test_runs_compose_force_recreate(self, stack_recovery, mocker):
+        mocker.patch("modules.stack_recovery.Config.IS_PRODUCTION", True)
+        mocker.patch(
+            "modules.stack_recovery.Config.RECREATE_SERVICES", "dragonite rotom-ng"
+        )
+        mocker.patch(
+            "modules.stack_recovery.Config.UNOWNHASH_COMPOSE_FILE",
+            "/root/unonwhash/docker-compose.yml",
+        )
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"done", None))
+        proc.returncode = 0
+        create = mocker.patch(
+            "modules.stack_recovery.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        )
+        assert await stack_recovery.recreate_services() is True
+        args = create.await_args.args
+        assert args[:6] == (
+            "docker-compose",
+            "-f",
+            "/root/unonwhash/docker-compose.yml",
+            "up",
+            "-d",
+            "--force-recreate",
+        )
+        assert args[6:] == ("dragonite", "rotom-ng")
+
+    async def test_nonzero_exit_returns_false(self, stack_recovery, mocker):
+        mocker.patch("modules.stack_recovery.Config.IS_PRODUCTION", True)
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"boom", None))
+        proc.returncode = 1
+        mocker.patch(
+            "modules.stack_recovery.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        )
+        assert await stack_recovery.recreate_services() is False
+
+    async def test_spawn_failure_returns_false(self, stack_recovery, mocker):
+        mocker.patch("modules.stack_recovery.Config.IS_PRODUCTION", True)
+        mocker.patch(
+            "modules.stack_recovery.asyncio.create_subprocess_exec",
+            new=AsyncMock(side_effect=FileNotFoundError("docker-compose")),
+        )
+        assert await stack_recovery.recreate_services() is False


### PR DESCRIPTION
Two-axis automatic recovery:

**Device offline** (tiered): 15 min offline → restart the PoGo app via ADB (tier 1, ~30s); still offline 10 min later → full device reboot (tier 2, existing 30 min cooldown). Failed app restart escalates immediately.

**Map fully red with device connected** (stuck accounts/sessions): after 10 min continuously red, force-recreate dragonite + rotom-ng via docker compose (45 min cooldown). DB/golbat/map untouched. Requires the new docker.sock + /root/unonwhash mounts and the compose binary added to the image.

New commands: `!device restartapp`, `!container recreate`, `!container autorecreate on|off` (DB-persisted toggle, migration 005).