### PR TITLE
refactor(Recovery): simplify to red ladder — recreate on red, device reboot at 15 min [P157]

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,17 @@ Most subcommands accept a **ref** — a `#channel` mention, a raw channel id, a 
 - `!accounts` — render the current account-pool status as an image
 - `!status` *(admin)* — live diagnostic snapshot: last pokémon seen, Rotom devices, Dragonite workers, account pool
 - `!container start|stop` *(admin)* — control the scanner container
+- `!container recreate` *(admin)* — force-recreate the scanner containers (dragonite + rotom-ng)
+- `!container autorecreate on|off` *(admin)* — toggle the automatic red-map recovery ladder
 - `!device status` *(admin)* — check ADB connectivity to the device
+- `!device restartapp` *(admin)* — force-stop and relaunch Pokémon GO via ADB
 - `!device logcat [lines]` *(admin)* — last N logcat lines filtered by aegis/poke
 - `!device autoreboot on|off` *(admin)* — toggle automatic ADB reboot when the device goes offline
 - `!device reboot` *(admin)* — reboot the device via ADB
 
 Voice channels mirror scanner health per region: 🟢 all workers up, 🟡/🟠 partially down (Leiria), 🔴 all workers down but device connected (account problem), ❌ device offline, ❓ status unknown.
+
+When both regions go red, the recovery ladder kicks in automatically: dragonite + rotom-ng are force-recreated immediately; if the map is still red 15 minutes later the device is rebooted via ADB (30 min reboot cooldown, shared with the offline watchdog).
 
 ## Project layout
 

--- a/modules/device_manager.py
+++ b/modules/device_manager.py
@@ -11,8 +11,6 @@ class DeviceManager:
     OFFLINE_BEFORE_REBOOT = 900  # 15 minutes offline before acting
     # Minimum gap between reboots — long enough for the device to fully boot + reconnect.
     AUTO_REBOOT_COOLDOWN = 1800  # 30 minutes between reboots
-    # Tier 1: restart the app first; only reboot if it's still down this much later.
-    APP_RESTART_GRACE = 600  # 10 minutes for the app restart to take effect
 
     POGO_PACKAGE = "com.nianticlabs.pokemongo"
     POGO_ACTIVITY = (
@@ -25,7 +23,6 @@ class DeviceManager:
         self._last_auto_reboot: float = 0
         self._offline_since: float | None = None
         self._last_notification_time: float = 0
-        self._app_restart_time: float | None = None
 
     @property
     def auto_reboot_enabled(self) -> bool:
@@ -163,6 +160,20 @@ class DeviceManager:
         except RuntimeError:
             return False
 
+    async def reboot_with_cooldown(self) -> bool:
+        """Reboot, but only if auto-reboot is enabled and the cooldown passed.
+
+        Shared by every automatic path (offline watchdog, red-map ladder) so
+        they can't stack reboots on top of each other.
+        """
+        if not Config.ADB_DEVICE or not self.auto_reboot_enabled:
+            return False
+        now = time.time()
+        if now - self._last_auto_reboot < self.AUTO_REBOOT_COOLDOWN:
+            return False
+        self._last_auto_reboot = now
+        return await self.reboot()
+
     async def restart_app(self) -> bool:
         """Force-stop and relaunch Pokémon GO. Much lighter than a reboot.
 
@@ -189,12 +200,12 @@ class DeviceManager:
         return 6 * 3600  # every 6 h after that
 
     async def auto_reboot_if_offline(self) -> bool:
-        """Recover the device if Rotom reports it offline long enough.
+        """Reboot the device if Rotom reports it offline long enough.
 
-        Tiered: at OFFLINE_BEFORE_REBOOT (15 min) the app is restarted first —
-        an app-level wedge is the common case and costs ~30s instead of a full
-        boot. If the device is still offline APP_RESTART_GRACE (10 min) after
-        that, the device is rebooted, respecting AUTO_REBOOT_COOLDOWN (30 min).
+        The red-map ladder (StackRecovery) is the primary self-healing path;
+        this watchdog covers the case where the worker-status endpoint is
+        unreachable (no red signal) but the device itself is gone. Reboots go
+        through reboot_with_cooldown, sharing the cooldown with that ladder.
 
         Notification cadence:
         - First alert at OFFLINE_BEFORE_REBOOT (15 min).
@@ -209,7 +220,6 @@ class DeviceManager:
         if device_alive:
             self._offline_since = None
             self._last_notification_time = 0
-            self._app_restart_time = None
             return False
 
         if self._offline_since is None:
@@ -221,50 +231,16 @@ class DeviceManager:
         if offline_duration < self.OFFLINE_BEFORE_REBOOT:
             return False
 
-        # Tier 1: one app restart per offline episode, before any reboot.
-        if self._app_restart_time is None:
-            self._log(
-                f"Device offline for {int(offline_duration)}s — restarting the app first",
-                "INFO",
+        rebooted = await self.reboot_with_cooldown()
+        if rebooted:
+            self._offline_since = None
+            self._last_notification_time = 0
+            self._log("Auto ADB reboot sent successfully", "INFO")
+            await self._notify(
+                f"📵 Dispositivo offline há **{int(offline_duration // 60)} min** — "
+                f"reboot automático via ADB enviado para `{Config.ADB_DEVICE}`."
             )
-            restarted = await self.restart_app()
-            if restarted:
-                self._app_restart_time = now
-                await self._notify(
-                    f"📵 Dispositivo offline há **{int(offline_duration // 60)} min** — "
-                    f"app reiniciada via ADB (tier 1). Reboot completo em "
-                    f"{self.APP_RESTART_GRACE // 60} min se continuar em baixo."
-                )
-                return True
-            # Failed restart gets no grace period — escalate to reboot now.
-            self._app_restart_time = now - self.APP_RESTART_GRACE
-            self._log("Tier 1 app restart failed — falling through to reboot")
-
-        # Tier 2: full reboot once the app restart had its grace period.
-        if (
-            self._app_restart_time is not None
-            and now - self._app_restart_time < self.APP_RESTART_GRACE
-        ):
-            return False
-
-        since_last_reboot = now - self._last_auto_reboot
-        if since_last_reboot >= self.AUTO_REBOOT_COOLDOWN:
-            self._log(
-                f"Device offline for {int(offline_duration)}s — triggering auto ADB reboot",
-                "INFO",
-            )
-            rebooted = await self.reboot()
-            self._last_auto_reboot = now
-            if rebooted:
-                self._offline_since = None
-                self._last_notification_time = 0
-                self._app_restart_time = None
-                self._log("Auto ADB reboot sent successfully", "INFO")
-                await self._notify(
-                    f"📵 Dispositivo offline há **{int(offline_duration // 60)} min** — "
-                    f"reboot automático via ADB enviado para `{Config.ADB_DEVICE}`."
-                )
-                return True
+            return True
 
         # Notify with escalating throttle (first notification fires immediately)
         since_last_notify = now - self._last_notification_time

--- a/modules/scanner_status.py
+++ b/modules/scanner_status.py
@@ -88,9 +88,10 @@ class ScannerStatus:
         if "🔴" in indicators:
             device_connected = await self.poliswag.account_monitor.is_device_connected()
 
-        # Fully red with the device still connected = stuck account/session
-        # state; StackRecovery recreates the scanner containers if it persists.
-        all_red = indicators == ("🔴", "🔴") and device_connected
+        # Fully red — regardless of the device flag (❌ is only a display
+        # distinction) — feeds the StackRecovery ladder: containers first,
+        # device reboot if red persists.
+        all_red = indicators == ("🔴", "🔴")
         await self.poliswag.stack_recovery.observe(all_red)
 
         for channel_key, counter, region in [

--- a/modules/stack_recovery.py
+++ b/modules/stack_recovery.py
@@ -6,20 +6,22 @@ from modules.config import Config
 
 
 class StackRecovery:
-    """Recreates the scanner-side containers when the map goes fully red.
+    """Escalation ladder for a fully red map (every region all-workers-down).
 
-    "Red" here means every region reports all workers down while the MITM
-    device is still connected — the signature of an exhausted/stuck account
-    pool rather than a device problem. Experience shows a fresh dragonite
-    (and rotom-ng) container clears it, so after the red state persists past
-    RED_BEFORE_RECREATE the affected services are force-recreated via docker
-    compose. The db/golbat/map containers are deliberately left alone.
+    Rung 1 — first red tick: force-recreate the scanner containers (dragonite
+    + rotom-ng) via docker compose. Red already implies ~10 min of dead
+    workers (the liveness window), so no extra debounce is needed. The
+    db/golbat/map containers are deliberately left alone.
+
+    Rung 2 — red persists past DEVICE_REBOOT_AFTER: reboot the phone via ADB
+    (through DeviceManager, sharing its reboot cooldown so the offline path
+    can't double-reboot).
     """
 
-    # How long the full-red state must persist before acting.
-    RED_BEFORE_RECREATE = 600  # 10 minutes
     # Minimum gap between recreations — enough for a full account warm-up.
-    RECREATE_COOLDOWN = 2700  # 45 minutes
+    RECREATE_COOLDOWN = 1800  # 30 minutes
+    # Red persisting this long after rung 1 escalates to a device reboot.
+    DEVICE_REBOOT_AFTER = 900  # 15 minutes
     # docker compose can take a while pulling/recreating; don't hang the loop.
     RECREATE_TIMEOUT = 180
 
@@ -52,10 +54,10 @@ class StackRecovery:
             self._log(f"Failed to persist auto_recreate_enabled: {e}")
 
     async def observe(self, all_red: bool) -> bool:
-        """Track the red state across ticks; recreate once it persists.
+        """Advance the red escalation ladder one tick.
 
         Called every scheduler tick from the voice-channel status pass.
-        Returns True when a recreation was triggered this tick.
+        Returns True when an action (recreate or reboot) was taken.
         """
         now = time.time()
 
@@ -65,39 +67,46 @@ class StackRecovery:
 
         if self._red_since is None:
             self._red_since = now
-            return False
-
-        red_duration = now - self._red_since
-        if red_duration < self.RED_BEFORE_RECREATE:
-            return False
 
         if not self.auto_recreate_enabled:
             return False
 
-        if now - self._last_recreate < self.RECREATE_COOLDOWN:
-            return False
+        red_duration = now - self._red_since
 
-        self._last_recreate = now
-        self._log(
-            f"Map fully red for {int(red_duration)}s with device connected — "
-            f"recreating {Config.RECREATE_SERVICES}",
-            "INFO",
-        )
-        ok = await self.recreate_services()
-        minutes = int(red_duration // 60)
-        if ok:
-            await self._notify(
-                f"🔄 Mapa em baixo há **{minutes} min** com o dispositivo ligado — "
-                f"containers `{Config.RECREATE_SERVICES}` recriados automaticamente."
+        # Rung 1: fresh containers, immediately on red.
+        if now - self._last_recreate >= self.RECREATE_COOLDOWN:
+            self._last_recreate = now
+            self._log(
+                f"Map fully red — recreating {Config.RECREATE_SERVICES}",
+                "INFO",
             )
-            # Fresh containers need time to come up; restart the red clock.
-            self._red_since = None
-        else:
-            await self._notify(
-                f"⚠️ Mapa em baixo há **{minutes} min** — recriação automática dos "
-                f"containers **falhou**. Intervenção manual necessária."
-            )
-        return ok
+            ok = await self.recreate_services()
+            if ok:
+                await self._notify(
+                    f"🔄 Mapa em baixo — containers `{Config.RECREATE_SERVICES}` "
+                    f"recriados automaticamente. Reboot do dispositivo em "
+                    f"{self.DEVICE_REBOOT_AFTER // 60} min se continuar em baixo."
+                )
+            else:
+                await self._notify(
+                    "⚠️ Mapa em baixo — recriação automática dos containers "
+                    "**falhou**. Intervenção manual necessária."
+                )
+            return ok
+
+        # Rung 2: red survived the fresh containers — reboot the phone.
+        if red_duration >= self.DEVICE_REBOOT_AFTER:
+            rebooted = await self.poliswag.device_manager.reboot_with_cooldown()
+            if rebooted:
+                await self._notify(
+                    f"📵 Mapa em baixo há **{int(red_duration // 60)} min** apesar dos "
+                    f"containers novos — reboot do dispositivo enviado via ADB."
+                )
+                # Give the phone a full boot cycle before judging red again.
+                self._red_since = None
+                return True
+
+        return False
 
     async def recreate_services(self) -> bool:
         """Run docker compose up -d --force-recreate on the scanner services."""

--- a/tests/modules/test_device_manager.py
+++ b/tests/modules/test_device_manager.py
@@ -112,8 +112,39 @@ class TestRestartApp:
         assert await device_manager.restart_app() is False
 
 
-class TestTieredAutoReboot:
-    """auto_reboot_if_offline: app restart first, reboot only after the grace."""
+class TestRebootWithCooldown:
+    def _prime(self, device_manager, mocker, *, enabled=True):
+        mocker.patch.object(Config, "ADB_DEVICE", "1.2.3.4:5555")
+        mocker.patch.object(
+            type(device_manager),
+            "auto_reboot_enabled",
+            new_callable=mocker.PropertyMock,
+            return_value=enabled,
+        )
+        mocker.patch("modules.device_manager.time.time", return_value=10_000)
+
+    async def test_reboots_and_arms_cooldown(self, device_manager, mocker):
+        self._prime(device_manager, mocker)
+        device_manager.reboot = AsyncMock(return_value=True)
+        assert await device_manager.reboot_with_cooldown() is True
+        assert device_manager._last_auto_reboot == 10_000
+
+    async def test_cooldown_blocks_second_reboot(self, device_manager, mocker):
+        self._prime(device_manager, mocker)
+        device_manager._last_auto_reboot = 10_000 - 600  # 10 min < 30 min cooldown
+        device_manager.reboot = AsyncMock()
+        assert await device_manager.reboot_with_cooldown() is False
+        device_manager.reboot.assert_not_called()
+
+    async def test_disabled_toggle_blocks_reboot(self, device_manager, mocker):
+        self._prime(device_manager, mocker, enabled=False)
+        device_manager.reboot = AsyncMock()
+        assert await device_manager.reboot_with_cooldown() is False
+        device_manager.reboot.assert_not_called()
+
+
+class TestAutoRebootIfOffline:
+    """Offline watchdog: plain reboot after 15 min offline, shared cooldown."""
 
     def _prime(self, device_manager, mocker, *, now, offline_since):
         mocker.patch.object(Config, "ADB_DEVICE", "1.2.3.4:5555")
@@ -130,66 +161,38 @@ class TestTieredAutoReboot:
         device_manager._offline_since = offline_since
         mocker.patch("modules.device_manager.time.time", return_value=now)
 
-    async def test_tier1_restarts_app_not_device(self, device_manager, mocker):
-        # 16 min offline, no app restart attempted yet → tier 1 fires.
+    async def test_reboots_after_threshold(self, device_manager, mocker):
         self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 960)
-        device_manager.restart_app = AsyncMock(return_value=True)
-        device_manager.reboot = AsyncMock()
+        device_manager.reboot = AsyncMock(return_value=True)
 
         assert await device_manager.auto_reboot_if_offline() is True
 
-        device_manager.restart_app.assert_awaited_once()
-        device_manager.reboot.assert_not_called()
-        assert device_manager._app_restart_time == 10_000
+        device_manager.reboot.assert_awaited_once()
+        assert device_manager._offline_since is None
 
-    async def test_tier2_waits_out_the_grace(self, device_manager, mocker):
-        # App restarted 5 min ago (grace is 10) → nothing happens yet.
-        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 1500)
-        device_manager._app_restart_time = 10_000 - 300
-        device_manager.restart_app = AsyncMock()
+    async def test_below_threshold_does_nothing(self, device_manager, mocker):
+        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 300)
         device_manager.reboot = AsyncMock()
 
         assert await device_manager.auto_reboot_if_offline() is False
 
-        device_manager.restart_app.assert_not_called()
         device_manager.reboot.assert_not_called()
 
-    async def test_tier2_reboots_after_grace(self, device_manager, mocker):
-        # App restarted 11 min ago and still offline → full reboot.
-        self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 2000)
-        device_manager._app_restart_time = 10_000 - 660
-        device_manager.restart_app = AsyncMock()
-        device_manager.reboot = AsyncMock(return_value=True)
-
-        assert await device_manager.auto_reboot_if_offline() is True
-
-        device_manager.restart_app.assert_not_called()
-        device_manager.reboot.assert_awaited_once()
-        # successful reboot resets the episode tracking
-        assert device_manager._offline_since is None
-        assert device_manager._app_restart_time is None
-
-    async def test_failed_app_restart_escalates_immediately(
-        self, device_manager, mocker
-    ):
-        # Tier 1 fails → no grace period, reboot fires in the same tick.
+    async def test_cooldown_blocks_repeat_reboot(self, device_manager, mocker):
         self._prime(device_manager, mocker, now=10_000, offline_since=10_000 - 960)
-        device_manager.restart_app = AsyncMock(return_value=False)
-        device_manager.reboot = AsyncMock(return_value=True)
+        device_manager._last_auto_reboot = 10_000 - 600
+        device_manager.reboot = AsyncMock()
 
-        assert await device_manager.auto_reboot_if_offline() is True
+        assert await device_manager.auto_reboot_if_offline() is False
 
-        device_manager.restart_app.assert_awaited_once()
-        device_manager.reboot.assert_awaited_once()
+        device_manager.reboot.assert_not_called()
 
-    async def test_device_back_online_resets_tiers(self, device_manager, mocker):
+    async def test_device_back_online_resets_tracking(self, device_manager, mocker):
         self._prime(device_manager, mocker, now=10_000, offline_since=9_000)
         device_manager.poliswag.account_monitor.is_device_connected = AsyncMock(
             return_value=True
         )
-        device_manager._app_restart_time = 9_500
 
         assert await device_manager.auto_reboot_if_offline() is False
 
         assert device_manager._offline_since is None
-        assert device_manager._app_restart_time is None

--- a/tests/modules/test_scanner_status.py
+++ b/tests/modules/test_scanner_status.py
@@ -782,13 +782,14 @@ class TestRenameVoiceChannels:
         await scanner_status.rename_voice_channels(4, 1)
         scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(True)
 
-    async def test_device_down_is_not_a_stack_recovery_case(
+    async def test_device_down_all_red_still_feeds_stack_recovery(
         self, scanner_status, mocker
     ):
-        # Fully red but device offline → ❌ path, not container recreation.
+        # ❌ is only a display distinction — the recovery ladder runs either
+        # way (containers first, device reboot if red persists).
         self._patch_fresh(scanner_status, mocker, seconds_ago=1, device_connected=False)
         await scanner_status.rename_voice_channels(4, 1)
-        scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(False)
+        scanner_status.poliswag.stack_recovery.observe.assert_awaited_once_with(True)
 
     async def test_partial_red_is_not_all_red(self, scanner_status, mocker):
         # Leiria red but Marinha green → no stack recovery trigger.

--- a/tests/modules/test_stack_recovery.py
+++ b/tests/modules/test_stack_recovery.py
@@ -10,6 +10,7 @@ def stack_recovery(mocker):
     """A StackRecovery with a mocked poliswag and auto-recreate enabled."""
     sr = StackRecovery(poliswag=MagicMock())
     sr.poliswag.MOD_CHANNEL = None
+    sr.poliswag.device_manager.reboot_with_cooldown = AsyncMock(return_value=False)
     mocker.patch.object(
         type(sr),
         "auto_recreate_enabled",
@@ -24,44 +25,67 @@ def _at(mocker, now):
 
 
 class TestObserve:
+    """Red ladder: recreate on first red tick, device reboot once it persists."""
+
     async def test_not_red_resets_tracking(self, stack_recovery, mocker):
         _at(mocker, 10_000)
         stack_recovery._red_since = 9_000
         assert await stack_recovery.observe(False) is False
         assert stack_recovery._red_since is None
 
-    async def test_first_red_tick_only_arms_the_timer(self, stack_recovery, mocker):
+    async def test_first_red_tick_recreates_immediately(self, stack_recovery, mocker):
         _at(mocker, 10_000)
-        stack_recovery.recreate_services = AsyncMock()
-        assert await stack_recovery.observe(True) is False
-        stack_recovery.recreate_services.assert_not_called()
-        assert stack_recovery._red_since == 10_000
-
-    async def test_red_below_threshold_does_nothing(self, stack_recovery, mocker):
-        _at(mocker, 10_000)
-        stack_recovery._red_since = 10_000 - 300  # 5 min < 10 min threshold
-        stack_recovery.recreate_services = AsyncMock()
-        assert await stack_recovery.observe(True) is False
-        stack_recovery.recreate_services.assert_not_called()
-
-    async def test_persistent_red_triggers_recreate(self, stack_recovery, mocker):
-        _at(mocker, 10_000)
-        stack_recovery._red_since = 10_000 - 700  # 11+ min red
         stack_recovery.recreate_services = AsyncMock(return_value=True)
         assert await stack_recovery.observe(True) is True
         stack_recovery.recreate_services.assert_awaited_once()
-        # red clock restarts so the fresh containers get time to come up
-        assert stack_recovery._red_since is None
+        # red clock stays armed — reboot escalation counts from first red tick
+        assert stack_recovery._red_since == 10_000
 
-    async def test_cooldown_blocks_back_to_back_recreates(self, stack_recovery, mocker):
+    async def test_recreate_cooldown_blocks_repeat(self, stack_recovery, mocker):
         _at(mocker, 10_000)
-        stack_recovery._red_since = 10_000 - 700
-        stack_recovery._last_recreate = 10_000 - 600  # 10 min ago < 45 min cooldown
+        stack_recovery._red_since = 10_000 - 300
+        stack_recovery._last_recreate = 10_000 - 600  # 10 min < 30 min cooldown
         stack_recovery.recreate_services = AsyncMock()
         assert await stack_recovery.observe(True) is False
         stack_recovery.recreate_services.assert_not_called()
 
-    async def test_disabled_toggle_blocks_recreate(self, stack_recovery, mocker):
+    async def test_persistent_red_reboots_device(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 960  # 16 min red
+        stack_recovery._last_recreate = 10_000 - 900  # recreate already fired
+        stack_recovery.recreate_services = AsyncMock()
+        reboot = stack_recovery.poliswag.device_manager.reboot_with_cooldown
+        reboot.return_value = True
+
+        assert await stack_recovery.observe(True) is True
+
+        stack_recovery.recreate_services.assert_not_called()
+        reboot.assert_awaited_once()
+        # successful reboot restarts the episode so the boot gets a window
+        assert stack_recovery._red_since is None
+
+    async def test_reboot_cooldown_leaves_episode_armed(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 960
+        stack_recovery._last_recreate = 10_000 - 900
+        reboot = stack_recovery.poliswag.device_manager.reboot_with_cooldown
+        reboot.return_value = False  # blocked by cooldown / disabled / failed
+
+        assert await stack_recovery.observe(True) is False
+
+        assert stack_recovery._red_since == 10_000 - 960
+
+    async def test_red_below_reboot_threshold_waits(self, stack_recovery, mocker):
+        _at(mocker, 10_000)
+        stack_recovery._red_since = 10_000 - 600  # 10 min < 15 min threshold
+        stack_recovery._last_recreate = 10_000 - 540
+        reboot = stack_recovery.poliswag.device_manager.reboot_with_cooldown
+
+        assert await stack_recovery.observe(True) is False
+
+        reboot.assert_not_called()
+
+    async def test_disabled_toggle_blocks_ladder(self, stack_recovery, mocker):
         _at(mocker, 10_000)
         mocker.patch.object(
             type(stack_recovery),
@@ -69,20 +93,18 @@ class TestObserve:
             new_callable=mocker.PropertyMock,
             return_value=False,
         )
-        stack_recovery._red_since = 10_000 - 700
         stack_recovery.recreate_services = AsyncMock()
         assert await stack_recovery.observe(True) is False
         stack_recovery.recreate_services.assert_not_called()
 
-    async def test_failed_recreate_keeps_red_clock_running(
+    async def test_failed_recreate_still_allows_later_reboot(
         self, stack_recovery, mocker
     ):
         _at(mocker, 10_000)
-        stack_recovery._red_since = 10_000 - 700
         stack_recovery.recreate_services = AsyncMock(return_value=False)
         assert await stack_recovery.observe(True) is False
-        # failure: red_since stays armed so the alert cadence continues
-        assert stack_recovery._red_since == 10_000 - 700
+        # red clock armed from this tick — the reboot rung can still fire later
+        assert stack_recovery._red_since == 10_000
 
 
 class TestRecreateServices:


### PR DESCRIPTION
Collapses the two-axis recovery into one red-driven ladder:

- Both regions red → force-recreate dragonite + rotom-ng immediately (red already implies ~10 min of dead workers; 30 min recreate cooldown).
- Still red 15 min later → reboot the device via ADB.

The ❌/🔴 split stays display-only; the ladder runs either way. The automatic app-restart tier is gone (`!device restartapp` remains as a manual command). The offline watchdog stays as a fallback for when the worker-status endpoint gives no red signal, now sharing the 30 min reboot cooldown via `reboot_with_cooldown` so the paths can never double-reboot.